### PR TITLE
収支データのグラフ表示機能追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/material": "^6.1.10",
         "@reduxjs/toolkit": "^2.3.0",
         "axios": "^1.7.8",
+        "d3-scale-chromatic": "^3.1.0",
         "lodash": "^4.17.21",
         "next": "15.0.3",
         "react": "^18.3.1",
@@ -23,9 +24,11 @@
         "react-hook-form": "^7.54.0",
         "react-redux": "^9.1.2",
         "react-toastify": "^10.0.6",
+        "recharts": "^2.15.0",
         "yup": "^1.5.0"
       },
       "devDependencies": {
+        "@types/d3-scale-chromatic": "^3.1.0",
         "@types/lodash": "^4.17.13",
         "@types/node": "^20",
         "@types/react": "^18",
@@ -1492,6 +1495,76 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
+      "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -2511,6 +2584,140 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -2598,6 +2805,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3443,6 +3656,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3456,6 +3675,15 @@
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.1.3.tgz",
+      "integrity": "sha512-6117/nJPFyrTjoCBQI7lpRFf+Oda4mH8HtlNMi28os+URb7MQU/dXUTrKhA2KR4G0O1MCfdi/KExIVEmzEh3qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -4023,6 +4251,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5582,6 +5819,21 @@
         }
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-toastify": {
       "version": "10.0.6",
       "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.6.tgz",
@@ -5633,6 +5885,44 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.0.tgz",
+      "integrity": "sha512-cIvMxDfpAmqAmVgc4yb7pgm/O1tmmkl/CjrvXuW+62/+7jj/iF9Ykm+hb/UJt42TREHMyd3gb+pkgoa2MxgDIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.0",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/redux": {
       "version": "5.0.1",
@@ -6500,6 +6790,12 @@
       "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6723,6 +7019,28 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@mui/material": "^6.1.10",
     "@reduxjs/toolkit": "^2.3.0",
     "axios": "^1.7.8",
+    "d3-scale-chromatic": "^3.1.0",
     "lodash": "^4.17.21",
     "next": "15.0.3",
     "react": "^18.3.1",
@@ -24,9 +25,11 @@
     "react-hook-form": "^7.54.0",
     "react-redux": "^9.1.2",
     "react-toastify": "^10.0.6",
+    "recharts": "^2.15.0",
     "yup": "^1.5.0"
   },
   "devDependencies": {
+    "@types/d3-scale-chromatic": "^3.1.0",
     "@types/lodash": "^4.17.13",
     "@types/node": "^20",
     "@types/react": "^18",

--- a/src/app/home/page.module.css
+++ b/src/app/home/page.module.css
@@ -1,0 +1,9 @@
+.title {
+  font-size: 20px;
+  font-weight: bold;
+  margin-top: 16px;
+}
+.toggleButton {
+  display: flex;
+  justify-content: center;
+}

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,12 +1,24 @@
 "use client";
 import TransactionForm from "@/src/components/TransactionForm";
-import { SubmitButton, Modal, NotificationSnackbar } from "../../components/UI";
+import {
+  SubmitButton,
+  Modal,
+  NotificationSnackbar,
+  MyPieChart,
+  ToggleButtonComponent,
+} from "../../components/UI";
 import { useState, useEffect } from "react";
 import TransactionTableList from "@/src/components/TransactionTableList";
 import { fetchTransactions, fetchCategories } from "@/src/utils/api";
-import { Transaction, Category } from "@/src/types/types";
+import {
+  Transaction,
+  Category,
+  CalculatedMonthlyTransaction,
+} from "@/src/types/types";
 import { useDispatch } from "react-redux";
 import { AppDispatch } from "@/src/features/store";
+import { fetchCalculatedMonthlyTransactions } from "@/src/utils/api";
+import styles from "./page.module.css";
 
 export default function Home() {
   const [openModal, setOpenModal] = useState(false);
@@ -14,7 +26,10 @@ export default function Home() {
   const [snackbarAction, setSnackbarAction] = useState<"register" | "delete">();
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
+  const [calculatedMonthlyTransactions, setCalculatedMonthlyTransactions] =
+    useState<CalculatedMonthlyTransaction[]>([]);
   const [isSubmitted, setIsSubmitted] = useState(false);
+  const [selectedOption, setSelectedOption] = useState("支出");
 
   const handleOpenModal = () => setOpenModal(true);
   const handleCloseModal = () => setOpenModal(false);
@@ -25,20 +40,41 @@ export default function Home() {
     setSnackbarStatus(type);
     setSnackbarAction(action);
   };
+  const handleToggleChange = (newOption: string) => {
+    setSelectedOption(newOption);
+  };
   const dispatch = useDispatch<AppDispatch>();
 
   useEffect(() => {
     const fetch = async () => {
       const transactionData = await dispatch(fetchTransactions());
       const categoryData = await dispatch(fetchCategories());
+      const calculatedMonthlyTransactionData = await dispatch(
+        fetchCalculatedMonthlyTransactions(),
+      );
       setTransactions(transactionData.payload);
       setCategories(categoryData.payload);
+      setCalculatedMonthlyTransactions(
+        calculatedMonthlyTransactionData.payload,
+      );
     };
     fetch();
   }, [isSubmitted, dispatch]);
 
   return (
     <div>
+      <h1 className={styles.title}>今月の収支</h1>
+      <div className={styles.toggleButton}>
+        <ToggleButtonComponent
+          label={["支出", "収入"]}
+          handleToggleChange={handleToggleChange}
+        />
+      </div>
+      <MyPieChart
+        calculatedTransactionData={calculatedMonthlyTransactions}
+        transactionType={selectedOption === "支出" ? "expense" : "income"}
+        category={categories}
+      />
       <TransactionTableList
         transactionData={transactions}
         categoryData={categories}

--- a/src/components/MyPieChart.tsx
+++ b/src/components/MyPieChart.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { PieChart, Pie, Cell } from "recharts";
+import { ResponsiveContainer, PieChart, Pie, Cell } from "recharts";
 import { CalculatedMonthlyTransaction, Category } from "@/src/types/types";
 import { formatDate } from "../utils/dateUtils";
 import { schemeCategory10 } from "d3-scale-chromatic";
@@ -35,23 +35,38 @@ const MyPieChart: React.FC<CustomPieChartProps> = ({
   );
 
   return (
-    <PieChart width={1000} height={400}>
-      <Pie
-        data={arrayData}
-        cx="50%"
-        cy="50%"
-        outerRadius={150}
-        fill="#8884d8"
-        dataKey="value"
-        label={({ name, value }) => `${name}: ${value}`}
-        startAngle={90}
-        endAngle={-270}
-      >
-        {arrayData.map((entry, index) => (
-          <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-        ))}
-      </Pie>
-    </PieChart>
+    <div style={{ width: "100%", height: "50vh" }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <PieChart>
+          <Pie
+            data={arrayData}
+            cx="50%"
+            cy="50%"
+            outerRadius={150}
+            innerRadius={75}
+            fill="#8884d8"
+            dataKey="value"
+            label={({ name, value }) => `${name}: ${value}円`}
+            startAngle={90}
+            endAngle={-270}
+          >
+            {arrayData.map((entry, index) => (
+              <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+            ))}
+          </Pie>
+          <text
+            x="50%"
+            y="50%"
+            textAnchor="middle"
+            dominantBaseline="middle"
+            fontSize="20px"
+            fill="#000"
+          >
+            合計：{Math.round(data.total)}円
+          </text>
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
   );
 };
 

--- a/src/components/MyPieChart.tsx
+++ b/src/components/MyPieChart.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { PieChart, Pie, Cell } from "recharts";
+import { CalculatedMonthlyTransaction, Category } from "@/src/types/types";
+import { formatDate } from "../utils/dateUtils";
+import { schemeCategory10 } from "d3-scale-chromatic";
+
+interface CustomPieChartProps {
+  calculatedTransactionData: CalculatedMonthlyTransaction[];
+  transactionType: string;
+  category: Category[];
+}
+
+const COLORS = schemeCategory10;
+
+const MyPieChart: React.FC<CustomPieChartProps> = ({
+  calculatedTransactionData,
+  transactionType,
+  category,
+}) => {
+  const date = new Date();
+  const beginningDate = new Date(date.getFullYear(), date.getMonth(), 1);
+  const data = calculatedTransactionData.find(
+    (transaction) =>
+      formatDate(transaction.month) === formatDate(beginningDate) &&
+      transaction.transactionType === transactionType,
+  );
+  if (!data) {
+    return <div>データがありません</div>;
+  }
+  const arrayData = Object.entries(data.totalByCategory).map(
+    ([key, value]) => ({
+      name: category.find((c) => c.id === Number(key))?.name,
+      value: value,
+    }),
+  );
+
+  return (
+    <PieChart width={1000} height={400}>
+      <Pie
+        data={arrayData}
+        cx="50%"
+        cy="50%"
+        outerRadius={150}
+        fill="#8884d8"
+        dataKey="value"
+        label={({ name, value }) => `${name}: ${value}`}
+        startAngle={90}
+        endAngle={-270}
+      >
+        {arrayData.map((entry, index) => (
+          <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+        ))}
+      </Pie>
+    </PieChart>
+  );
+};
+
+export default MyPieChart;

--- a/src/components/MyPieChart.tsx
+++ b/src/components/MyPieChart.tsx
@@ -51,7 +51,10 @@ const MyPieChart: React.FC<CustomPieChartProps> = ({
             endAngle={-270}
           >
             {arrayData.map((entry, index) => (
-              <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+              <Cell
+                key={`cell-${index}`}
+                fill={COLORS[index % COLORS.length]}
+              />
             ))}
           </Pie>
           <text

--- a/src/components/TransactionTableList.tsx
+++ b/src/components/TransactionTableList.tsx
@@ -107,7 +107,7 @@ const EnhancedTableToolbar: React.FC<EnhancedTableToolbarProps> = ({
           id="tableTitle"
           component="div"
         >
-          今月の収支
+          収支一覧
         </Typography>
       )}
       {selected.length > 0 ? (

--- a/src/components/UI/index.ts
+++ b/src/components/UI/index.ts
@@ -3,3 +3,5 @@ export { default as InputField } from "./InputField";
 export { default as MultipleLineInputField } from "./MultipleLineInputField";
 export { default as Modal } from "./Modal";
 export { default as NotificationSnackbar } from "./Snackbar";
+export { default as MyPieChart } from "../MyPieChart";
+export { default as ToggleButtonComponent } from "./toggleButton";

--- a/src/components/UI/toggleButton.tsx
+++ b/src/components/UI/toggleButton.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from "react";
+import { ToggleButton, ToggleButtonGroup } from "@mui/material";
+
+interface ToggleButtonProps {
+  label: Array<string>;
+  handleToggleChange: (newOption: string) => void;
+}
+
+const ToggleButtonComponent: React.FC<ToggleButtonProps> = ({
+  label,
+  handleToggleChange,
+}) => {
+  const [selected, setSelected] = useState(label[0]);
+
+  const handleChange = (
+    event: React.MouseEvent<HTMLElement>,
+    newOption: string | null,
+  ) => {
+    if (newOption !== null) {
+      setSelected(newOption);
+      handleToggleChange(newOption);
+    }
+  };
+
+  return (
+    <ToggleButtonGroup value={selected} exclusive onChange={handleChange}>
+      <ToggleButton value={label[0]} aria-label={label[0]}>
+        {label[0]}
+      </ToggleButton>
+      <ToggleButton value={label[1]} aria-label={label[1]}>
+        {label[1]}
+      </ToggleButton>
+    </ToggleButtonGroup>
+  );
+};
+
+export default ToggleButtonComponent;

--- a/src/features/calculatedMonthlyTransactionSlice.ts
+++ b/src/features/calculatedMonthlyTransactionSlice.ts
@@ -1,0 +1,34 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { fetchCalculatedMonthlyTransactions } from "@/src/utils/api";
+import { CalculatedMonthlyTransactionState } from "@/src/types/types";
+
+const initialState: CalculatedMonthlyTransactionState = {
+  calculatedMonthlyTransactions: [],
+  status: "idle",
+  error: null,
+};
+
+const calculatedMonthlyTransactionSlice = createSlice({
+  name: "calculatedMonthlyTransactions",
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchCalculatedMonthlyTransactions.pending, (state) => {
+        state.status = "loading";
+      })
+      .addCase(
+        fetchCalculatedMonthlyTransactions.fulfilled,
+        (state, action) => {
+          state.status = "succeeded";
+          state.calculatedMonthlyTransactions = action.payload;
+        },
+      )
+      .addCase(fetchCalculatedMonthlyTransactions.rejected, (state, action) => {
+        state.status = "failed";
+        state.error = action.payload as string;
+      });
+  },
+});
+
+export default calculatedMonthlyTransactionSlice.reducer;

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -1,11 +1,13 @@
 import { configureStore } from "@reduxjs/toolkit";
 import transactionReducer from "./transactionSlice";
 import categoryReducer from "./categorySlice";
+import calculatedMonthlyTransactionReducer from "./calculatedMonthlyTransactionSlice";
 
 const store = configureStore({
   reducer: {
     transactions: transactionReducer,
     categories: categoryReducer,
+    calculatedMonthlyTransactions: calculatedMonthlyTransactionReducer,
   },
 });
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -25,3 +25,19 @@ export interface CategoryState {
   status: "idle" | "loading" | "succeeded" | "failed";
   error: string | null;
 }
+
+export interface CalculatedMonthlyTransaction {
+  id: number;
+  month: Date;
+  total: number;
+  totalByCategory: { [key: string]: number };
+  percentageByCategory: { [key: string]: number };
+  transactionType: string;
+  userId: number;
+}
+
+export interface CalculatedMonthlyTransactionState {
+  calculatedMonthlyTransactions: CalculatedMonthlyTransaction[];
+  status: "idle" | "loading" | "succeeded" | "failed";
+  error: string | null;
+}

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -101,3 +101,19 @@ export const fetchCategories = createAsyncThunk(
     }
   },
 );
+
+export const fetchCalculatedMonthlyTransactions = createAsyncThunk(
+  "CalculatedMonthlyTransactions/fetchCalculatedMonthlyTransactions",
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await apiClient.get("/calculated_monthly_transactions");
+      console.log("テスト2", response.data);
+      return toCamelCase(response.data);
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        return rejectWithValue(error.response?.data?.message);
+      }
+      return rejectWithValue("An unexpected error occurred");
+    }
+  },
+);

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -107,7 +107,6 @@ export const fetchCalculatedMonthlyTransactions = createAsyncThunk(
   async (_, { rejectWithValue }) => {
     try {
       const response = await apiClient.get("/calculated_monthly_transactions");
-      console.log("テスト2", response.data);
       return toCamelCase(response.data);
     } catch (error) {
       if (axios.isAxiosError(error)) {


### PR DESCRIPTION
## 概要
登録した収支データを円グラフとして表示する機能を追加

## 変更の詳細と背景
登録した収支を視覚的に確認しやすくするために、月毎の収支を円グラフの形で表示できるようにする。
- CalculatedMonthlyTransactionsを取得するための処理を実装
- 円グラフを表示するためのコンポーネントを実装し、page.tsxに追加
- トグルボタンで支出と収入のデータを切り替えられるようにする

### 導入した技術
Reactのグラフ描画のライブラリであるRechartsを利用し円グラフを実装

### 実装上の工夫
トグルボタンのコンポーネントを用意し、別の部分でも使用できるようにした。

## テスト
https://github.com/user-attachments/assets/da4c2e42-5a4e-4c2c-abeb-4757de75ccf4

## 関連
https://github.com/kobayashi0201/kakeibo_backend/pull/24